### PR TITLE
Add Lexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ bin
 
 # Generated files
 include/basilisk/config.h
+
+# clang-tidy log
+clang-tidy.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(basilisk_VERSION_FULL "${basilisk_VERSION_MAJOR}.${basilisk_VERSION_MINOR}.$
 # Declare options
 option(basilisk_BUILD_DOC "Build documentation" ON)
 option(basilisk_BUILD_TEST "Build tests" ON)
+option(basilisk_BUILD_TOOLS "Build tools" ON)
 set(basilisk_BOOST "/opt/boost" CACHE PATH "Boost directory")
 set(basilisk_LLVM "/opt/llvm" CACHE PATH "LLVM directory")
 
@@ -73,4 +74,9 @@ if (basilisk_BUILD_TEST)
     foreach(test ${basilisk_TESTS})
         add_test(NAME ${test} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test COMMAND ${CMAKE_BINARY_DIR}/test/${test})
     endforeach(test)
+endif()
+
+
+if (basilisk_BUILD_TOOLS)
+    add_subdirectory(tools)
 endif()

--- a/include/basilisk/Lexer.h
+++ b/include/basilisk/Lexer.h
@@ -35,7 +35,7 @@ namespace basilisk::lexer {
     //! Output append function type - single Token argument and no return
     typedef std::function<void (tokens::Token)> append_function_t;
 
-    void lex(get_function_t get, peek_function_t peek, append_function_t append);
+    void lex(const get_function_t &get, const peek_function_t &peek, const append_function_t &append);
 
     /** \class LexerException
      * \brief Exception during lexing (for example an invalid character)

--- a/include/basilisk/Lexer.h
+++ b/include/basilisk/Lexer.h
@@ -30,10 +30,12 @@ namespace basilisk::lexer {
 
     //! Input get function type - no arguments and return a single character
     typedef std::function<char ()> get_function_t;
+    //! Input peek function type - no arguments and return a single character
+    typedef std::function<char ()> peek_function_t;
     //! Output append function type - single Token argument and no return
     typedef std::function<void (tokens::Token)> append_function_t;
 
-    void lex(get_function_t get, append_function_t append);
+    void lex(get_function_t get, peek_function_t peek, append_function_t append);
 
     /** \class LexerException
      * \brief Exception during lexing (for example an invalid character)

--- a/include/basilisk/Lexer.h
+++ b/include/basilisk/Lexer.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <functional>
+#include <exception>
 
 // Forward declarations
 namespace basilisk::tokens {
@@ -33,6 +34,14 @@ namespace basilisk::lexer {
     typedef std::function<void (tokens::Token)> append_function_t;
 
     void lex(get_function_t get, append_function_t append);
+
+    /** \class LexerException
+     * \brief Exception during lexing (for example an invalid character)
+     */
+    class LexerException : public std::runtime_error {
+        public:
+            explicit LexerException(const std::string &message) : std::runtime_error(message) {}
+    };
 
     /**
      * @}

--- a/include/basilisk/Tokens.h
+++ b/include/basilisk/Tokens.h
@@ -42,24 +42,27 @@ namespace basilisk::tokens {
         /** \enum token_tag
          *  \brief Token tag
          */
+        // Note: These identifiers are used to represent the tags in code, text should still use the names as the
+        //  grammar definition states them for consistency with documentation.
+        // Note: Prefix "kw_" used to signify keyword (and prevent recognition by compiler)
         enum token_tag {
-            IDENTIFIER,
-            LPAR,
-            RPAR,
-            LBRAC,
-            RBRAC,
-            COMMA,
-            SEMICOLON,
-            ASSIGN,
-            RETURN,
-            DOUBLE_LITERAL,
-            PLUS,
-            MINUS,
-            STAR,
-            SLASH,
-            PERCENT,
-            ERROR,
-            END
+            identifier,
+            lpar,
+            rpar,
+            lbrac,
+            rbrac,
+            comma,
+            semicolon,
+            assign,
+            kw_return,
+            double_literal,
+            plus,
+            minus,
+            star,
+            slash,
+            percent,
+            error,
+            end_of_input
         };
     }
 

--- a/include/basilisk/Tokens.h
+++ b/include/basilisk/Tokens.h
@@ -7,6 +7,7 @@
 #define BASILISK_TOKENS_H
 
 #include <string>
+#include <ostream>
 
 //! Token definitions
 namespace basilisk::tokens {
@@ -57,7 +58,8 @@ namespace basilisk::tokens {
             STAR,
             SLASH,
             PERCENT,
-            ERROR
+            ERROR,
+            END
         };
     }
 
@@ -78,6 +80,12 @@ namespace basilisk::tokens {
         }
 
         friend bool operator!=(const Token &lhs, const Token &rhs) { return !(rhs == lhs); }
+
+        friend std::ostream &operator<<(std::ostream &os, const Token &token) {
+            //TODO: implement with tag names
+            os << "tag: " << token.tag << " content: " << token.content;
+            return os;
+        }
     };
 
 

--- a/include/basilisk/Tokens.h
+++ b/include/basilisk/Tokens.h
@@ -82,8 +82,39 @@ namespace basilisk::tokens {
         friend bool operator!=(const Token &lhs, const Token &rhs) { return !(rhs == lhs); }
 
         friend std::ostream &operator<<(std::ostream &os, const Token &token) {
-            //TODO: implement with tag names
-            os << "tag: " << token.tag << " content: " << token.content;
+            // Tag labels in the same order as the enumeration
+            static const char* labels[] = {
+                    "IDENTIFIER",
+                    "LPAR",
+                    "RPAR",
+                    "LBRAC",
+                    "RBRAC",
+                    "COMMA",
+                    "SEMICOLON",
+                    "ASSIGN",
+                    "RETURN",
+                    "DOUBLE_LITERAL",
+                    "PLUS",
+                    "MINUS",
+                    "STAR",
+                    "SLASH",
+                    "PERCENT",
+                    "ERROR",
+                    "END"
+            };
+
+            // Append the tag
+            if (static_cast<std::size_t>(token.tag) < sizeof(labels) / sizeof(*labels)) {
+                os << labels[token.tag];
+            } else {
+                os << static_cast<int>(token.tag);
+            }
+
+            // Append the contents if non-empty
+            if (!token.content.empty()) {
+                os << "{" << token.content << "}";
+            }
+
             return os;
         }
     };

--- a/include/basilisk/config.h.in
+++ b/include/basilisk/config.h.in
@@ -21,9 +21,6 @@ namespace basilisk {
     constexpr char version_version[] = "@basilisk_VERSION@";
     //! Full version string (\c major.minor.patchextra)
     constexpr char version_full[] = "@basilisk_VERSION_FULL@";
-
-    //! Whether debug logging should be enabled
-    constexpr bool debug_log = @basilisk_DEBUG_LOG_VALUE@;
 }
 
 #endif //BASILISK_CONFIG_H

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -16,10 +16,10 @@ namespace basilisk::lexer {
     //! Symbols that translate directly to tokens
     constexpr char special_symbols[] = {'(', ')', '{', '}', ',', ';', '=', '+', '-', '*', '/', '%'};
     //! Tags for the special symbols in the same order
-    constexpr tokens::tags::token_tag special_tags[] = {tokens::tags::LPAR, tokens::tags::RPAR, tokens::tags::LBRAC,
-                                                        tokens::tags::RBRAC, tokens::tags::COMMA, tokens::tags::SEMICOLON,
-                                                        tokens::tags::ASSIGN, tokens::tags::PLUS, tokens::tags::MINUS,
-                                                        tokens::tags::STAR, tokens::tags::SLASH, tokens::tags::PERCENT};
+    constexpr tokens::tags::token_tag special_tags[] = {tokens::tags::lpar, tokens::tags::rpar, tokens::tags::lbrac,
+                                                        tokens::tags::rbrac, tokens::tags::comma, tokens::tags::semicolon,
+                                                        tokens::tags::assign, tokens::tags::plus, tokens::tags::minus,
+                                                        tokens::tags::star, tokens::tags::slash, tokens::tags::percent};
     //! End of file character
     constexpr char end_of_file = std::char_traits<char>::eof();
 
@@ -76,9 +76,9 @@ namespace basilisk::lexer {
         // Decide what token to append
         std::string content = stream.str();
         if (content == return_pattern) {
-            append(tokens::Token{tokens::tags::RETURN, ""});
+            append(tokens::Token{tokens::tags::kw_return, ""});
         } else {
-            append(tokens::Token{tokens::tags::IDENTIFIER, content});
+            append(tokens::Token{tokens::tags::identifier, content});
         }
     }
 
@@ -111,7 +111,7 @@ namespace basilisk::lexer {
                 // Invalid input --> append error token and throw exception
                 std::ostringstream message;
                 message << "Unexpected character: \'" << c << "\', expecting a decimal point.";
-                append(tokens::Token{tokens::tags::ERROR, message.str()});
+                append(tokens::Token{tokens::tags::error, message.str()});
                 throw LexerException(message.str());
             } else {
                 stream << c;
@@ -126,7 +126,7 @@ namespace basilisk::lexer {
                 get();
                 std::ostringstream message;
                 message << "Unexpected character: \'" << c << "\', expecting a digit.";
-                append(tokens::Token{tokens::tags::ERROR, message.str()});
+                append(tokens::Token{tokens::tags::error, message.str()});
                 throw LexerException(message.str());
             }
         }
@@ -137,7 +137,7 @@ namespace basilisk::lexer {
         }
 
         // Append the token
-        append(tokens::Token{tokens::tags::DOUBLE_LITERAL, stream.str()});
+        append(tokens::Token{tokens::tags::double_literal, stream.str()});
     }
 
     // Lexing itself
@@ -161,7 +161,7 @@ namespace basilisk::lexer {
             if (is_end(next)) {                         // Detect end of input
                 // Eat it, append token, stop
                 get();
-                append(tokens::Token{tokens::tags::END, ""});
+                append(tokens::Token{tokens::tags::end_of_input, ""});
                 stop = true;
             } else if (std::isspace(next) > 0) {        // Detect whitespace
                 // Eat it
@@ -178,7 +178,7 @@ namespace basilisk::lexer {
                 get();
                 std::ostringstream message;
                 message << "Unknown character: \'" << next << "\'.";
-                append(tokens::Token{tokens::tags::ERROR, message.str()});
+                append(tokens::Token{tokens::tags::error, message.str()});
                 throw LexerException(message.str());
             }
         } while (!stop);

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -5,8 +5,23 @@
  */
 
 #include <basilisk/Lexer.h>
+#include <basilisk/Tokens.h>
+
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+#include <string>
 
 namespace basilisk::lexer {
+    //! Symbols that translate directly to tokens
+    constexpr char special_symbols[] = {'(', ')', '{', '}', ',', ';', '=', '+', '-', '*', '/', '%'};
+    //! Tags for the special symbols in the same order
+    constexpr tokens::tags::token_tag special_tags[] = {tokens::tags::LPAR, tokens::tags::RPAR, tokens::tags::LBRAC,
+                                                        tokens::tags::RBRAC, tokens::tags::COMMA, tokens::tags::SEMICOLON,
+                                                        tokens::tags::ASSIGN, tokens::tags::PLUS, tokens::tags::MINUS,
+                                                        tokens::tags::STAR, tokens::tags::SLASH, tokens::tags::PERCENT};
+    //! End of file character
+    constexpr char end_of_file = std::char_traits<char>::eof();
 
     /**
      * \brief Lex from an input character buffer into an output Token buffer
@@ -18,6 +33,151 @@ namespace basilisk::lexer {
      * \param append Function to write next output Token
      */
     void lex(get_function_t get, append_function_t append) {
-        //TODO: implement
+        // Prepare the state variables
+        bool stop = false;
+        std::ostringstream content;
+        constexpr char ret_pattern[] = {'r', 'e', 't', 'u', 'r', 'n'};
+        unsigned ret_idx = 0;
+        bool ret = false;
+        bool identifier = false;
+        bool double_literal = false;
+        bool after_period = false;
+
+        // Keep grabbing input until told to stop
+        do {
+            // Grab the next character
+            char c = get();
+
+            // Find the character in the special symbols array
+            const char *p = std::find(std::begin(special_symbols), std::end(special_symbols), c);
+            bool is_special = p != std::end(special_symbols);
+
+            // Check if the character is end of input
+            bool is_end =  c == '\0' || c == end_of_file;
+
+            // Handle special symbols, whitespace and end of input
+            if (is_special || std::isspace(c) != 0 || is_end) {
+                // Check if return was read
+                if (ret_idx == 6) {
+                    // Append the return token
+                    append(tokens::Token{tokens::tags::RETURN, ""});
+
+                    // Set identifier to false as this was a valid return
+                    identifier = false;
+                }
+
+                // Check if identifier was read
+                if (identifier) {
+                    // Append the identifier token
+                    append(tokens::Token{tokens::tags::IDENTIFIER, content.str()});
+                }
+
+                // Check if double literal was read
+                if (double_literal) {
+                    // Append the double literal token
+                    append(tokens::Token{tokens::tags::DOUBLE_LITERAL, content.str()});
+                }
+
+                // Reset complex token state variables
+                //TODO: try clearing instead of creating a new stream
+                content = std::ostringstream();
+                ret_idx = 0;
+                ret = false;
+                identifier = false;
+                double_literal = false;
+                after_period = false;
+
+                // Append the relevant token if special or stop if end of input
+                if (is_special) {
+                    // Compute the index of the special symbol
+                    auto i = p - special_symbols;
+
+                    // Append the relevant token
+                    append(tokens::Token{special_tags[i], ""});
+                } else if (is_end) {
+                    // Append the end token
+                    append(tokens::Token{tokens::tags::END, ""});
+
+                    // Stop
+                    stop = true;
+                }
+            } else {
+                // The character is a part of a complex token or is an error --> check expectations
+                if (identifier) {
+                    // Expecting identifier (or return) --> valid: alphanumeric and underscore
+                    if (std::isalnum(c) != 0 || c == '_') {
+                        // Add to the content
+                        content << c;
+
+                        // Check if next return character
+                        if (ret && ret_idx < 6 && c == ret_pattern[ret_idx]) {
+                            // Advance
+                            ret_idx++;
+                        } else {
+                            // Not return
+                            ret_idx = 0;
+                            ret = false;
+                        }
+                    } else {
+                        // Invalid --> append error token and throw exception
+                        std::ostringstream message;
+                        message << "Invalid identifier or return character: \'" << c << "\'.";
+                        append(tokens::Token{tokens::tags::ERROR, message.str()});
+                        //TODO: throw exception
+                    }
+                } else if (double_literal) {
+                    // Expecting double literal --> valid: digits and period (iff not yet encountered)
+                    if (c == '.') {
+                        if (after_period) {
+                            // Period already encountered --> append error token and throw exception
+                            std::ostringstream message;
+                            message << "Invalid period in double literal.";
+                            append(tokens::Token{tokens::tags::ERROR, message.str()});
+                            //TODO: throw exception
+                        } else {
+                            // Add to the content and update flag
+                            content << c;
+                            after_period = true;
+                        }
+                    } else if (std::isdigit(c) != 0) {
+                        // Add to the content
+                        content << c;
+                    } else {
+                        // Invalid --> append error token and throw exception
+                        std::ostringstream message;
+                        message << "Invalid double literal character: \'" << c << "\'.";
+                        append(tokens::Token{tokens::tags::ERROR, message.str()});
+                        //TODO: throw exception
+                    }
+                } else {
+                    // Not expecting anything --> valid: alpha for identifier or return, digit for double literal
+                    if (std::isalpha(c) != 0) {
+                        // Add to content
+                        content << c;
+
+                        // Expect identifier
+                        identifier = true;
+
+                        // Decide whether to expect return
+                        if (c == 'r') {
+                            ret = true;
+                            ret_idx = 1;
+                        }
+                    } else if (std::isdigit(c) != 0) {
+                        // Add to content
+                        content << c;
+
+                        // Expect double literal
+                        double_literal = true;
+                    } else {
+                        // Invalid --> append error token and throw exception
+                        std::ostringstream message;
+                        message << "Unknown character: \'" << c << "\'.";
+                        append(tokens::Token{tokens::tags::ERROR, message.str()});
+                        //TODO: throw exception
+                    }
+                }
+            }
+        } while (!stop);
     }
 }

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -30,9 +30,10 @@ namespace basilisk::lexer {
      *  them into an output Token buffer.
      *
      * \param get Function to get next input character
+     * \param peek Function to peek at next input character
      * \param append Function to write next output Token
      */
-    void lex(get_function_t get, append_function_t append) {
+    void lex(get_function_t get, peek_function_t /*peek*/, append_function_t append) {
         // Prepare the state variables
         bool stop = false;
         std::ostringstream content;

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -123,7 +123,7 @@ namespace basilisk::lexer {
                         std::ostringstream message;
                         message << "Invalid identifier or return character: \'" << c << "\'.";
                         append(tokens::Token{tokens::tags::ERROR, message.str()});
-                        //TODO: throw exception
+                        throw LexerException(message.str());
                     }
                 } else if (double_literal) {
                     // Expecting double literal --> valid: digits and period (iff not yet encountered)
@@ -133,7 +133,7 @@ namespace basilisk::lexer {
                             std::ostringstream message;
                             message << "Invalid period in double literal.";
                             append(tokens::Token{tokens::tags::ERROR, message.str()});
-                            //TODO: throw exception
+                            throw LexerException(message.str());
                         } else {
                             // Add to the content and update flag
                             content << c;
@@ -147,7 +147,7 @@ namespace basilisk::lexer {
                         std::ostringstream message;
                         message << "Invalid double literal character: \'" << c << "\'.";
                         append(tokens::Token{tokens::tags::ERROR, message.str()});
-                        //TODO: throw exception
+                        throw LexerException(message.str());
                     }
                 } else {
                     // Not expecting anything --> valid: alpha for identifier or return, digit for double literal
@@ -174,7 +174,7 @@ namespace basilisk::lexer {
                         std::ostringstream message;
                         message << "Unknown character: \'" << c << "\'.";
                         append(tokens::Token{tokens::tags::ERROR, message.str()});
-                        //TODO: throw exception
+                        throw LexerException(message.str());
                     }
                 }
             }

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -149,47 +149,6 @@ BOOST_AUTO_TEST_CASE( fixture_test ) {
     BOOST_CHECK(q.output.front() == subject_token);
 }
 
-//! Test single naive tokens lex (excluding special tokens END and ERROR)
-BOOST_AUTO_TEST_CASE(unit_naive_lexes) {
-    // Dataset - (input, token) pairs
-    std::map<std::string, tokens::Token> data{
-        {"identifier", {tags::IDENTIFIER, "identifier"}},
-        {"(", {tags::LPAR, ""}},
-        {")", {tags::RPAR, ""}},
-        {"{", {tags::LBRAC, ""}},
-        {"}", {tags::RBRAC, ""}},
-        {",", {tags::COMMA, ""}},
-        {";", {tags::SEMICOLON, ""}},
-        {"=", {tags::ASSIGN, ""}},
-        {"return", {tags::RETURN, ""}},
-        {"3.14", {tags::DOUBLE_LITERAL, "3.14"}},
-        {"+", {tags::PLUS, ""}},
-        {"-", {tags::MINUS, ""}},
-        {"*", {tags::STAR, ""}},
-        {"/", {tags::SLASH, ""}},
-        {"%", {tags::PERCENT, ""}}};
-
-    // Test each input results in the assigned token
-    for (auto pair : data) {
-        // Prepare fixture
-        QueuesFixture q;
-        q.load(pair.first);
-
-        // Lex the input
-        q.lex();
-
-        // Check tokens were added (token for input and END)
-        BOOST_TEST_CHECK(q.output.size() == 2);
-
-        // Check the token is correct if present
-        if (q.output.size() == 2) {
-            BOOST_TEST_CHECK(q.output.front() == pair.second,
-                             "\"" << pair.first << "\" should lex to " << pair.second << ", lexes to "
-                                  << q.output.front());
-        }
-    }
-}
-
 /**
  * \brief Test whether the provided input lexes into the correct tokens
  *
@@ -211,6 +170,146 @@ void test_input(const std::string &input, QueuesFixture::out_queue_t correct) {
     BOOST_TEST_CHECK(q.output == correct, "\"" << input << "\" should lex to " << print_queue(correct)
                                                << ", lexes to "<< print_queue(q.output));
 }
+
+//! Test single naive tokens lex (excluding special tokens END and ERROR)
+BOOST_AUTO_TEST_SUITE(unit_naive_lexes)
+
+BOOST_AUTO_TEST_CASE(identifier) {
+    // Data
+    std::string input = "identifier";
+    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "identifier"}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(lpar) {
+    // Data
+    std::string input = "(";
+    QueuesFixture::out_queue_t correct({{tags::LPAR, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(rpar) {
+    // Data
+    std::string input = ")";
+    QueuesFixture::out_queue_t correct({{tags::RPAR, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(lbrac) {
+    // Data
+    std::string input = "{";
+    QueuesFixture::out_queue_t correct({{tags::LBRAC, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(rbrac) {
+    // Data
+    std::string input = "}";
+    QueuesFixture::out_queue_t correct({{tags::RBRAC, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(comma) {
+    // Data
+    std::string input = ",";
+    QueuesFixture::out_queue_t correct({{tags::COMMA, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(semicolon) {
+    // Data
+    std::string input = ";";
+    QueuesFixture::out_queue_t correct({{tags::SEMICOLON, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(assign) {
+    // Data
+    std::string input = "=";
+    QueuesFixture::out_queue_t correct({{tags::ASSIGN, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(unit_return) {
+    // Data
+    std::string input = "return";
+    QueuesFixture::out_queue_t correct({{tags::RETURN, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(double_literal) {
+    // Data
+    std::string input = "3.14";
+    QueuesFixture::out_queue_t correct({{tags::DOUBLE_LITERAL, "3.14"}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(plus) {
+    // Data
+    std::string input = "+";
+    QueuesFixture::out_queue_t correct({{tags::PLUS, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(minus) {
+    // Data
+    std::string input = "-";
+    QueuesFixture::out_queue_t correct({{tags::MINUS, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(star) {
+    // Data
+    std::string input = "*";
+    QueuesFixture::out_queue_t correct({{tags::STAR, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(slash) {
+    // Data
+    std::string input = "/";
+    QueuesFixture::out_queue_t correct({{tags::SLASH, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_CASE(percent) {
+    // Data
+    std::string input = "%";
+    QueuesFixture::out_queue_t correct({{tags::PERCENT, ""}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // unit_naive_lexes
 
 //! Test special symbols and whitespace ending complex tokens (identifier, return, double literal)
 BOOST_AUTO_TEST_SUITE(special_end_complex)

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -11,13 +11,20 @@
 #include <boost/test/unit_test.hpp>
 
 #include <queue>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace tokens = basilisk::tokens;
+namespace tags = tokens::tags;
+namespace lexer = basilisk::lexer;
 
 //! Fixture that sets up two queues for use as lexer input and output
 struct QueuesFixture {
     //! Lexer input queue type
     typedef std::queue<char> in_queue_t;
     //! Lexer output queue type
-    typedef std::queue<basilisk::tokens::Token> out_queue_t;
+    typedef std::queue<tokens::Token> out_queue_t;
 
     //! Lexer input queue
     in_queue_t input;
@@ -45,14 +52,14 @@ struct QueuesFixture {
      *
      * \param t Token to push
      */
-    void append(const basilisk::tokens::Token &t) { output.push(t); }
+    void append(const tokens::Token &t) { output.push(t); }
 };
 
 //! Test fixture is working correctly
 BOOST_AUTO_TEST_CASE( fixture_test ) {
     // Constants in this test
     constexpr char subject_character = 'a';
-    basilisk::tokens::Token subject_token{basilisk::tokens::tags::ASSIGN, {}};
+    tokens::Token subject_token{tags::ASSIGN, {}};
 
     // Construct fixture
     QueuesFixture q;
@@ -77,4 +84,51 @@ BOOST_AUTO_TEST_CASE( fixture_test ) {
 
     // Pop output
     BOOST_CHECK(q.output.front() == subject_token);
+}
+
+//! Test single naive tokens lex (excluding special tokens END and ERROR)
+BOOST_AUTO_TEST_CASE(unit_naive_lexes) {
+    // Dataset - (input, token) pairs
+    std::map<std::string, tokens::Token> data{
+        {"identifier", {tags::IDENTIFIER, "identifier"}},
+        {"(", {tags::LPAR, ""}},
+        {")", {tags::RPAR, ""}},
+        {"{", {tags::LBRAC, ""}},
+        {"}", {tags::RBRAC, ""}},
+        {",", {tags::COMMA, ""}},
+        {";", {tags::SEMICOLON, ""}},
+        {"=", {tags::ASSIGN, ""}},
+        {"return", {tags::RETURN, ""}},
+        {"3.14", {tags::DOUBLE_LITERAL, "3.14"}},
+        {"+", {tags::PLUS, ""}},
+        {"-", {tags::MINUS, ""}},
+        {"*", {tags::STAR, ""}},
+        {"/", {tags::SLASH, ""}},
+        {"%", {tags::PERCENT, ""}}};
+
+    // Test each input results in the assigned token
+    for(auto pair : data) {
+        // Prepare fixture
+        QueuesFixture q;
+
+        // Push input
+        for(const char& c : pair.first) {
+            q.input.push(c);
+        }
+
+        // Lex the input
+        auto get_f = std::bind(&QueuesFixture::get, &q);
+        auto append_f = std::bind(&QueuesFixture::append, &q, std::placeholders::_1);
+        lexer::lex(get_f, append_f);
+
+        // Check tokens were added (token for input and END)
+        BOOST_TEST_CHECK(q.output.size() == 2);
+
+        // Check the token is correct if present
+        if (q.output.size() == 2) {
+            BOOST_TEST_CHECK(q.output.front() == pair.second,
+                             "\"" << pair.first << "\" should lex to " << pair.second << ", instead lexes to "
+                                  << q.output.front());
+        }
+    }
 }

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -268,6 +268,15 @@ BOOST_AUTO_TEST_SUITE_END() // special_end_complex
 
 //TODO: test errors and exceptions happen where expected
 //TODO: check identifier starting with "return" is lexed properly into an identifier
-//TODO: check a more complex identiier (alphanum + underscore) is lexed properly
+
+//! Test more complex identifier lexing
+BOOST_AUTO_TEST_CASE(complex_identifier) {
+    // Data
+    std::string input = "this_identifier_15_c0mpl3x";
+    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "this_identifier_15_c0mpl3x"}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
 
 BOOST_AUTO_TEST_SUITE_END() // Lexer

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -387,69 +387,6 @@ BOOST_AUTO_TEST_SUITE_END() // special_end_complex
 //! Test exceptions and errors on invalid input
 BOOST_AUTO_TEST_SUITE(exceptions_and_errors)
 
-//! Test exception and error on invalid input when expecting identifier
-BOOST_AUTO_TEST_CASE(invalid_identifier) {
-    // Note: does not require the exact error message, just that an exception is thrown and error appended
-
-    // Data
-    std::string input = "identifier$";
-
-    // Prepare fixture
-    QueuesFixture q;
-    q.load(input);
-
-    // Lex the input (should throw LexerException)
-    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
-
-    // Check only one token was added
-    BOOST_TEST_CHECK(q.output.size() == 1);
-
-    // Check the last token is an ERROR
-    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
-}
-
-//! Test exception and error on second period in double literal
-BOOST_AUTO_TEST_CASE(second_period) {
-    // Note: does not require the exact error message, just that an exception is thrown and error appended
-
-    // Data
-    std::string input = "3.1.4";
-
-    // Prepare fixture
-    QueuesFixture q;
-    q.load(input);
-
-    // Lex the input (should throw LexerException)
-    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
-
-    // Check only one token was added
-    BOOST_TEST_CHECK(q.output.size() == 1);
-
-    // Check the last token is an ERROR
-    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
-}
-
-//! Test exception and error on invalid input when expecting double literal
-BOOST_AUTO_TEST_CASE(invalid_double) {
-    // Note: does not require the exact error message, just that an exception is thrown and error appended
-
-    // Data
-    std::string input = "3.14$";
-
-    // Prepare fixture
-    QueuesFixture q;
-    q.load(input);
-
-    // Lex the input (should throw LexerException)
-    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
-
-    // Check only one token was added
-    BOOST_TEST_CHECK(q.output.size() == 1);
-
-    // Check the last token is an ERROR
-    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
-}
-
 //! Test exception and error on invalid input when not expecting anything
 BOOST_AUTO_TEST_CASE(invalid_input) {
     // Note: does not require the exact error message, just that an exception is thrown and error appended

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -267,7 +267,16 @@ BOOST_AUTO_TEST_CASE(double_whitespace) {
 BOOST_AUTO_TEST_SUITE_END() // special_end_complex
 
 //TODO: test errors and exceptions happen where expected
-//TODO: check identifier starting with "return" is lexed properly into an identifier
+
+//! Test identifier starting with "return" is lexed properly into an identifier
+BOOST_AUTO_TEST_CASE(return_like_identifier) {
+    // Data
+    std::string input = "return_like_identifier";
+    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "return_like_identifier"}, {tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
 
 //! Test more complex identifier lexing
 BOOST_AUTO_TEST_CASE(complex_identifier) {

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_SUITE(Lexer)
 BOOST_AUTO_TEST_CASE( fixture_test ) {
     // Constants in this test
     constexpr char subject_character = 'a';
-    tokens::Token subject_token{tags::ASSIGN, {}};
+    tokens::Token subject_token{tags::assign, {}};
 
     // Construct fixture
     QueuesFixture q;
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_SUITE(unit_naive_lexes)
 BOOST_AUTO_TEST_CASE(identifier) {
     // Data
     std::string input = "identifier";
-    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "identifier"}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::identifier, "identifier"}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(identifier) {
 BOOST_AUTO_TEST_CASE(lpar) {
     // Data
     std::string input = "(";
-    QueuesFixture::out_queue_t correct({{tags::LPAR, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::lpar, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(lpar) {
 BOOST_AUTO_TEST_CASE(rpar) {
     // Data
     std::string input = ")";
-    QueuesFixture::out_queue_t correct({{tags::RPAR, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::rpar, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(rpar) {
 BOOST_AUTO_TEST_CASE(lbrac) {
     // Data
     std::string input = "{";
-    QueuesFixture::out_queue_t correct({{tags::LBRAC, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::lbrac, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(lbrac) {
 BOOST_AUTO_TEST_CASE(rbrac) {
     // Data
     std::string input = "}";
-    QueuesFixture::out_queue_t correct({{tags::RBRAC, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::rbrac, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(rbrac) {
 BOOST_AUTO_TEST_CASE(comma) {
     // Data
     std::string input = ",";
-    QueuesFixture::out_queue_t correct({{tags::COMMA, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::comma, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(comma) {
 BOOST_AUTO_TEST_CASE(semicolon) {
     // Data
     std::string input = ";";
-    QueuesFixture::out_queue_t correct({{tags::SEMICOLON, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::semicolon, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(semicolon) {
 BOOST_AUTO_TEST_CASE(assign) {
     // Data
     std::string input = "=";
-    QueuesFixture::out_queue_t correct({{tags::ASSIGN, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::assign, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(assign) {
 BOOST_AUTO_TEST_CASE(unit_return) {
     // Data
     std::string input = "return";
-    QueuesFixture::out_queue_t correct({{tags::RETURN, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::kw_return, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(unit_return) {
 BOOST_AUTO_TEST_CASE(double_literal) {
     // Data
     std::string input = "3.14";
-    QueuesFixture::out_queue_t correct({{tags::DOUBLE_LITERAL, "3.14"}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::double_literal, "3.14"}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(double_literal) {
 BOOST_AUTO_TEST_CASE(plus) {
     // Data
     std::string input = "+";
-    QueuesFixture::out_queue_t correct({{tags::PLUS, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::plus, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(plus) {
 BOOST_AUTO_TEST_CASE(minus) {
     // Data
     std::string input = "-";
-    QueuesFixture::out_queue_t correct({{tags::MINUS, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::minus, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(minus) {
 BOOST_AUTO_TEST_CASE(star) {
     // Data
     std::string input = "*";
-    QueuesFixture::out_queue_t correct({{tags::STAR, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::star, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(star) {
 BOOST_AUTO_TEST_CASE(slash) {
     // Data
     std::string input = "/";
-    QueuesFixture::out_queue_t correct({{tags::SLASH, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::slash, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(slash) {
 BOOST_AUTO_TEST_CASE(percent) {
     // Data
     std::string input = "%";
-    QueuesFixture::out_queue_t correct({{tags::PERCENT, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::percent, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_SUITE(special_end_complex)
 BOOST_AUTO_TEST_CASE(identifier_special) {
     // Data
     std::string input = "identifier)";
-    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "identifier"}, {tags::RPAR, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::identifier, "identifier"}, {tags::rpar, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(identifier_special) {
 BOOST_AUTO_TEST_CASE(identifier_whitespace) {
     // Data
     std::string input = "identifier  ";
-    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "identifier"}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::identifier, "identifier"}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(identifier_whitespace) {
 BOOST_AUTO_TEST_CASE(return_special) {
     // Data
     std::string input = "return)";
-    QueuesFixture::out_queue_t correct({{tags::RETURN, ""}, {tags::RPAR, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::kw_return, ""}, {tags::rpar, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(return_special) {
 BOOST_AUTO_TEST_CASE(return_whitespace) {
     // Data
     std::string input = "return  ";
-    QueuesFixture::out_queue_t correct({{tags::RETURN, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::kw_return, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(return_whitespace) {
 BOOST_AUTO_TEST_CASE(double_special) {
     // Data
     std::string input = "3.14)";
-    QueuesFixture::out_queue_t correct({{tags::DOUBLE_LITERAL, "3.14"}, {tags::RPAR, ""}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::double_literal, "3.14"}, {tags::rpar, ""}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE(double_special) {
 BOOST_AUTO_TEST_CASE(double_whitespace) {
     // Data
     std::string input = "3.14  ";
-    QueuesFixture::out_queue_t correct({{tags::DOUBLE_LITERAL, "3.14"}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::double_literal, "3.14"}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(invalid_input) {
     BOOST_TEST_CHECK(q.output.size() == 1);
 
     // Check the last token is an ERROR
-    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
+    BOOST_TEST_CHECK(q.output.front().tag == tags::error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_CASE(return_like_identifier) {
     // Data
     std::string input = "return_like_identifier";
-    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "return_like_identifier"}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::identifier, "return_like_identifier"}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(return_like_identifier) {
 BOOST_AUTO_TEST_CASE(complex_identifier) {
     // Data
     std::string input = "this_identifier_15_c0mpl3x";
-    QueuesFixture::out_queue_t correct({{tags::IDENTIFIER, "this_identifier_15_c0mpl3x"}, {tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::identifier, "this_identifier_15_c0mpl3x"}, {tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(complex_identifier) {
 BOOST_AUTO_TEST_CASE(empty) {
     // Data
     std::string input;
-    QueuesFixture::out_queue_t correct({{tags::END, ""}});
+    QueuesFixture::out_queue_t correct({{tags::end_of_input, ""}});
 
     // Test
     test_input(input, correct);

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -36,7 +36,7 @@ struct QueuesFixture {
     /**
      * \brief Pop a character from the front of the input queue and return it
      *
-     * \return Popped character
+     * \return Popped character, or the null character when empty
      */
     char get() {
         // Return null char if empty
@@ -52,9 +52,16 @@ struct QueuesFixture {
     /**
      * \brief Peek at the character at the front of the input queue
      *
-     * \return Character at the front of the input queue
+     * \return Character at the front of the input queue, or the null character when empty
      */
-    char peek() { return input.front(); }
+    char peek() {
+        // Return null char if empty
+        if (input.empty()) {
+            return '\0';
+        }
+
+        return input.front();
+    }
 
     /**
      * \brief Push a token to the end of the output queue

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -430,4 +430,14 @@ BOOST_AUTO_TEST_CASE(complex_identifier) {
     test_input(input, correct);
 }
 
+//! Test no input lexing
+BOOST_AUTO_TEST_CASE(empty) {
+    // Data
+    std::string input;
+    QueuesFixture::out_queue_t correct({{tags::END, ""}});
+
+    // Test
+    test_input(input, correct);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Lexer

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -50,6 +50,13 @@ struct QueuesFixture {
     }
 
     /**
+     * \brief Peek at the character at the front of the input queue
+     *
+     * \return Character at the front of the input queue
+     */
+    char peek() { return input.front(); }
+
+    /**
      * \brief Push a token to the end of the output queue
      *
      * \param t Token to push
@@ -72,8 +79,9 @@ struct QueuesFixture {
      */
     void lex() {
         auto get_f = std::bind(&QueuesFixture::get, this);
+        auto peek_f = std::bind(&QueuesFixture::peek, this);
         auto append_f = std::bind(&QueuesFixture::append, this, std::placeholders::_1);
-        lexer::lex(get_f, append_f);
+        lexer::lex(get_f, peek_f, append_f);
     }
 };
 
@@ -121,6 +129,9 @@ BOOST_AUTO_TEST_CASE( fixture_test ) {
 
     // Check input size
     BOOST_CHECK(q.input.size() == 1);
+
+    // Check peek
+    BOOST_CHECK(q.peek() == subject_character);
 
     // Get input
     BOOST_CHECK(q.get() == subject_character);

--- a/test/LexerTest.cpp
+++ b/test/LexerTest.cpp
@@ -267,6 +267,94 @@ BOOST_AUTO_TEST_CASE(double_whitespace) {
 BOOST_AUTO_TEST_SUITE_END() // special_end_complex
 
 //TODO: test errors and exceptions happen where expected
+//! Test exceptions and errors on invalid input
+BOOST_AUTO_TEST_SUITE(exceptions_and_errors)
+
+//! Test exception and error on invalid input when expecting identifier
+BOOST_AUTO_TEST_CASE(invalid_identifier) {
+    // Note: does not require the exact error message, just that an exception is thrown and error appended
+
+    // Data
+    std::string input = "identifier$";
+
+    // Prepare fixture
+    QueuesFixture q;
+    q.load(input);
+
+    // Lex the input (should throw LexerException)
+    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
+
+    // Check only one token was added
+    BOOST_TEST_CHECK(q.output.size() == 1);
+
+    // Check the last token is an ERROR
+    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
+}
+
+//! Test exception and error on second period in double literal
+BOOST_AUTO_TEST_CASE(second_period) {
+    // Note: does not require the exact error message, just that an exception is thrown and error appended
+
+    // Data
+    std::string input = "3.1.4";
+
+    // Prepare fixture
+    QueuesFixture q;
+    q.load(input);
+
+    // Lex the input (should throw LexerException)
+    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
+
+    // Check only one token was added
+    BOOST_TEST_CHECK(q.output.size() == 1);
+
+    // Check the last token is an ERROR
+    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
+}
+
+//! Test exception and error on invalid input when expecting double literal
+BOOST_AUTO_TEST_CASE(invalid_double) {
+    // Note: does not require the exact error message, just that an exception is thrown and error appended
+
+    // Data
+    std::string input = "3.14$";
+
+    // Prepare fixture
+    QueuesFixture q;
+    q.load(input);
+
+    // Lex the input (should throw LexerException)
+    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
+
+    // Check only one token was added
+    BOOST_TEST_CHECK(q.output.size() == 1);
+
+    // Check the last token is an ERROR
+    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
+}
+
+//! Test exception and error on invalid input when not expecting anything
+BOOST_AUTO_TEST_CASE(invalid_input) {
+    // Note: does not require the exact error message, just that an exception is thrown and error appended
+
+    // Data
+    std::string input = "$";
+
+    // Prepare fixture
+    QueuesFixture q;
+    q.load(input);
+
+    // Lex the input (should throw LexerException)
+    BOOST_CHECK_THROW(q.lex(), lexer::LexerException);
+
+    // Check only one token was added
+    BOOST_TEST_CHECK(q.output.size() == 1);
+
+    // Check the last token is an ERROR
+    BOOST_TEST_CHECK(q.output.front().tag == tags::ERROR);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 
 //! Test identifier starting with "return" is lexed properly into an identifier
 BOOST_AUTO_TEST_CASE(return_like_identifier) {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Include Boost and Basilisk headers
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+include_directories(${INCL_DIR})
+
+# Link libraries
+link_libraries(${Boost_LIBRARIES} basilisk)
+
+# Add lexer executable
+add_executable(lexer_executable lexer_executable.cpp)

--- a/tools/lexer_executable.cpp
+++ b/tools/lexer_executable.cpp
@@ -1,0 +1,132 @@
+/** \file lexer_executable.cpp
+ * Standalone basilisk Lexer
+ *
+ * \author Filip Smola
+ */
+
+#include <basilisk/Lexer.h>
+#include <basilisk/Tokens.h>
+#include <basilisk/config.h>
+
+#include <iostream>
+#include <fstream>
+#include <functional>
+
+/**
+ * \brief Print usage into standard error
+ *
+ * \param name Executable name
+ */
+void show_usage(const std::string &name) {
+    std::cerr << "Usage:\n"
+              << '\t' << name << '\n'                       // Stdin input, stdout output
+              << '\t' << name << " source\n"                // File input, stdout output
+              << '\t' << name << " source destination\n"    // File input, file output
+              << '\t' << name << " -h | --help\n"           // Show usage
+              << '\t' << name << " -v | --version\n"        // Show basilisk version
+              << '\n'
+              << "Options:\n"
+              << "\t-h --help\tShow this screen.\n"
+              << "\t-v --version\tShow Basilisk version.\n";
+}
+
+char stdin_get() { return static_cast<char>(std::cin.get()); }
+char stdin_peek() { return static_cast<char>(std::cin.peek()); }
+void stdout_append(const basilisk::tokens::Token &t) { std::cout << t << '|'; }
+
+/**
+ * \brief Lex standard input stream into standard output stream
+ */
+void lex_stdin_to_stdout() {
+    auto get_f = std::bind(&stdin_get);
+    auto peek_f = std::bind(&stdin_peek);
+    auto append_f = std::bind(&stdout_append, std::placeholders::_1);
+
+    basilisk::lexer::lex(get_f, peek_f, append_f);
+}
+
+char file_get(std::ifstream *stream) { return static_cast<char>(stream->get()); }
+char file_peek(std::ifstream *stream) { return static_cast<char>(stream->peek()); }
+
+/**
+ * \brief Lex file input stream into standard output stream
+ *
+ * \param source_filename Name of the source file
+ */
+void lex_file_to_stdout(const std::string &source_filename) {
+    // Open stream
+    std::ifstream stream(source_filename, std::ios::in);
+
+    if (!stream.is_open()) {
+        // Print error if not open
+        std::cerr << "Failed to open file " << source_filename << '\n';
+    } else {
+        auto get_f = std::bind(&file_get, &stream);
+        auto peek_f = std::bind(&file_peek, &stream);
+        auto append_f = std::bind(&stdout_append, std::placeholders::_1);
+
+        basilisk::lexer::lex(get_f, peek_f, append_f);
+    }
+}
+
+void file_append(std::ofstream *stream, const basilisk::tokens::Token &t) { (*stream) << t << '|'; }
+
+/**
+ * \brief Lex file input stream into file output stream
+ *
+ * \param source_filename Name of the source file
+ * \param destination_filename Name of the destination file
+ */
+void lex_file_to_file(const std::string &source_filename, const std::string &destination_filename) {
+    // Open stream
+    std::ifstream input(source_filename, std::ios::in);
+    std::ofstream output(destination_filename, std::ios::out);
+
+    if (!input.is_open()) {
+        // Print error if input not open
+        std::cerr << "Failed to open file " << source_filename << '\n';
+    } else if (!output.is_open()) {
+        // Print error if output not open
+        std::cerr << "Failed to open file " << destination_filename << '\n';
+    } else {
+        auto get_f = std::bind(&file_get, &input);
+        auto peek_f = std::bind(&file_peek, &input);
+        auto append_f = std::bind(&file_append, &output, std::placeholders::_1);
+
+        basilisk::lexer::lex(get_f, peek_f, append_f);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    // Compute actual argument number (without executable name)
+    std::string name = argv[0];
+    int n = argc - 1;
+
+    // Decide what to do
+    if (n == 0) {
+        // Stdin input, stdout output
+        lex_stdin_to_stdout();
+    } else if (n == 1) {
+        // Check the argument for help or version
+        std::string arg = argv[1];
+
+        if (arg == "-h" || arg == "--help") {
+            // Show usage
+            show_usage(name);
+        } else if (arg == "-v" || arg == "--version") {
+            // Show basilisk version
+            std::cout << "Basilisk " << basilisk::version_full << "\n";
+        } else {
+            // File input, stdout output
+            lex_file_to_stdout(arg);
+        }
+    } else if (n == 2) {
+        // File input, file output
+        std::string source = argv[1];
+        std::string destination = argv[2];
+        lex_file_to_file(source, destination);
+    } else {
+        // Invalid --> show usage
+        show_usage(name);
+    }
+}


### PR DESCRIPTION
- [x] Add a lexer that supports the current set of tokens as defined in the Grammar document.
- [x] Replace the original lexer with a more readable and maintainable one.
- [x] Add an executable that uses the lexer to lex a file and print out the tokens into standard output.